### PR TITLE
Refactor control catalog description and removal of Profile tab

### DIFF
--- a/_control-catalog/About Control Catalog.md
+++ b/_control-catalog/About Control Catalog.md
@@ -14,7 +14,7 @@ The catalog consists of a&nbsp;central pool of recommended controls meant for lo
 
 The controls are expressed using Open Security Controls Assessment Language (OSCAL) which are codified in machine-readable policy format. It enables future automation to monitor and assess the effectiveness of technical control implementation. Industry partners can get more info about OSCAL [here](https://pages.nist.gov/OSCAL/).
 
-The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed <a href="/profile/low-risk" rel="noopener noreferrer nofollow">here</a>.
+The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed <a href="/profile/low-risk/" rel="noopener noreferrer nofollow">here</a>.
 
 Each system is to define a system security plan that comprises the implementable controls.&nbsp; Agencies and their industry partners are to apply the controls identified for each system.
 

--- a/_control-catalog/About Control Catalog.md
+++ b/_control-catalog/About Control Catalog.md
@@ -14,7 +14,7 @@ The catalog consists of a&nbsp;central pool of recommended controls meant for lo
 
 The controls are expressed using Open Security Controls Assessment Language (OSCAL) which are codified in machine-readable policy format. It enables future automation to monitor and assess the effectiveness of technical control implementation. Industry partners can get more info about OSCAL [here](https://pages.nist.gov/OSCAL/).
 
-The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed <a href="/profile/low-risk/" rel="noopener noreferrer nofollow">here</a>.
+The controls are categorised into domain areas as listed on the left. Each control can either be a basic <strong>hygiene requirement</strong> which should be implemented or a <strong>guideline</strong> which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed <a href="/profile/low-risk/" rel="noopener noreferrer nofollow">here</a>.
 
 Each system is to define a system security plan that comprises the implementable controls.&nbsp; Agencies and their industry partners are to apply the controls identified for each system.
 

--- a/_control-catalog/About Control Catalog.md
+++ b/_control-catalog/About Control Catalog.md
@@ -14,7 +14,7 @@ The catalog consists of a&nbsp;central pool of recommended controls meant for lo
 
 The controls are expressed using Open Security Controls Assessment Language (OSCAL) which are codified in machine-readable policy format. It enables future automation to monitor and assess the effectiveness of technical control implementation. Industry partners can get more info about OSCAL [here](https://pages.nist.gov/OSCAL/).
 
-The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed <a href="/profile/" rel="noopener noreferrer nofollow">here</a>.
+The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed here.
 
 Each system is to define a system security plan that comprises the implementable controls.&nbsp; Agencies and their industry partners are to apply the controls identified for each system.
 

--- a/_control-catalog/About Control Catalog.md
+++ b/_control-catalog/About Control Catalog.md
@@ -14,10 +14,10 @@ The catalog consists of a&nbsp;central pool of recommended controls meant for lo
 
 The controls are expressed using Open Security Controls Assessment Language (OSCAL) which are codified in machine-readable policy format. It enables future automation to monitor and assess the effectiveness of technical control implementation. Industry partners can get more info about OSCAL [here](https://pages.nist.gov/OSCAL/).
 
-The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed [here]().
+The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed <a href="/profile/" rel="noopener noreferrer nofollow">here.
 
 Each system is to define a system security plan that comprises the implementable controls.&nbsp; Agencies and their industry partners are to apply the controls identified for each system.
 
 The first tranche of recommended controls for low-risk systems are published here and will progressively be updated in this website.
 
-We invite the industry players to join us in the ICT&amp;SS Reform journey. For&nbsp; any feedback, please provide [here.](https://go.gov.sg/ictpolicy)
+We invite the industry players to join us in the ICT&amp;SS Reform journey. For&nbsp; any feedback, please provide [here.](https://go.gov.sg/ictpolicy)</a>

--- a/_control-catalog/About Control Catalog.md
+++ b/_control-catalog/About Control Catalog.md
@@ -14,7 +14,7 @@ The catalog consists of a&nbsp;central pool of recommended controls meant for lo
 
 The controls are expressed using Open Security Controls Assessment Language (OSCAL) which are codified in machine-readable policy format. It enables future automation to monitor and assess the effectiveness of technical control implementation. Industry partners can get more info about OSCAL [here](https://pages.nist.gov/OSCAL/).
 
-The controls are categorised into groups (as listed on the left) that represent security baselines for selection and implementation in each system security plan.
+The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed [here]().
 
 Each system is to define a system security plan that comprises the implementable controls.&nbsp; Agencies and their industry partners are to apply the controls identified for each system.
 

--- a/_control-catalog/About Control Catalog.md
+++ b/_control-catalog/About Control Catalog.md
@@ -14,10 +14,10 @@ The catalog consists of a&nbsp;central pool of recommended controls meant for lo
 
 The controls are expressed using Open Security Controls Assessment Language (OSCAL) which are codified in machine-readable policy format. It enables future automation to monitor and assess the effectiveness of technical control implementation. Industry partners can get more info about OSCAL [here](https://pages.nist.gov/OSCAL/).
 
-The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed <a href="/profile/" rel="noopener noreferrer nofollow">here.
+The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed <a href="/profile/" rel="noopener noreferrer nofollow">here</a>.
 
 Each system is to define a system security plan that comprises the implementable controls.&nbsp; Agencies and their industry partners are to apply the controls identified for each system.
 
 The first tranche of recommended controls for low-risk systems are published here and will progressively be updated in this website.
 
-We invite the industry players to join us in the ICT&amp;SS Reform journey. For&nbsp; any feedback, please provide [here.](https://go.gov.sg/ictpolicy)</a>
+We invite the industry players to join us in the ICT&amp;SS Reform journey. For&nbsp; any feedback, please provide [here.](https://go.gov.sg/ictpolicy)

--- a/_control-catalog/About Control Catalog.md
+++ b/_control-catalog/About Control Catalog.md
@@ -14,7 +14,7 @@ The catalog consists of a&nbsp;central pool of recommended controls meant for lo
 
 The controls are expressed using Open Security Controls Assessment Language (OSCAL) which are codified in machine-readable policy format. It enables future automation to monitor and assess the effectiveness of technical control implementation. Industry partners can get more info about OSCAL [here](https://pages.nist.gov/OSCAL/).
 
-The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed here.
+The controls are categorised into domain areas as listed on the left. Each control can either be a basic hygiene requirement which should be implemented or a guideline which is best practice for consideration.&nbsp; A control can be tagged as requirement for low-risk systems but tagged as guideline for systems in sandbox stage. The list of controls for these 2 profiles are listed <a href="/profile/low-risk" rel="noopener noreferrer nofollow">here</a>.
 
 Each system is to define a system security plan that comprises the implementable controls.&nbsp; Agencies and their industry partners are to apply the controls identified for each system.
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,7 +4,5 @@ links:
     url: /about
   - title: Control Catalog
     url: /control-catalog
-  - title: Profile
-    url: /profile/low-risk
   - title: Contact Us
     url: /contact-us/


### PR DESCRIPTION
List of changes made:
1. Re-worded a section in the "About Control Catalog" based on suggestions from Jonathan and Beng Huay
2. Added the link to profiles in the "About Control Catalog" section
3. Removed the "Profile" tab in the navigation bar